### PR TITLE
feat: Implement HTTP method routing

### DIFF
--- a/mycppwebfw/.clang-format
+++ b/mycppwebfw/.clang-format
@@ -1,1 +1,69 @@
-# Clang-format rules
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+AccessModifierOffset: -4
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: "None"
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: "Yes"
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBraces: "Allman"
+BreakBeforeBinaryOperators: "None"
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: "BeforeColon"
+ColumnLimit: 80
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+IncludeBlocks: "Preserve"
+IncludeCategories:
+  - Regex:           '^<.*'
+    Priority:        1
+  - Regex:           '^"gtest/gtest.h"'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IndentCaseLabels: false
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: "None"
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: "Left"
+ReflowComments: true
+SortIncludes: true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: "ControlStatements"
+SpaceInEmptyParentheses: false
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Latest
+TabWidth: 4
+UseTab: "Never"

--- a/mycppwebfw/CMakeLists.txt
+++ b/mycppwebfw/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(mycppwebfw INTERFACE)
 
 target_include_directories(mycppwebfw INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src"
   "${asio_SOURCE_DIR}/asio/include"
   "${nlohmann_json_SOURCE_DIR}/include"
 )

--- a/mycppwebfw/benchmarks/routing_bench/router_bench.cpp
+++ b/mycppwebfw/benchmarks/routing_bench/router_bench.cpp
@@ -1,56 +1,91 @@
 #include "benchmark/benchmark.h"
+#include "mycppwebfw/http/request.h"
+#include "mycppwebfw/http/response.h"
 #include "mycppwebfw/routing/router.h"
 
-void dummy_handler(mycppwebfw::http::Request&, mycppwebfw::http::Response&) {}
+void dummy_handler(mycppwebfw::http::Request&, mycppwebfw::http::Response&)
+{
+}
 
-static void BM_Router_Static(benchmark::State& state) {
+static void BM_Router_Static(benchmark::State& state)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/hello", dummy_handler);
-    for (auto _ : state) {
+    mycppwebfw::http::Request req = {"GET", "/hello"};
+    for (auto _ : state)
+    {
         std::unordered_map<std::string, std::string> params;
-        router.match_route("GET", "/hello", params);
+        router.match_route(req, params);
     }
 }
 BENCHMARK(BM_Router_Static);
 
-static void BM_Router_Parameterized(benchmark::State& state) {
+static void BM_Router_Parameterized(benchmark::State& state)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/users/:id", dummy_handler);
-    for (auto _ : state) {
+    mycppwebfw::http::Request req = {"GET", "/users/123"};
+    for (auto _ : state)
+    {
         std::unordered_map<std::string, std::string> params;
-        router.match_route("GET", "/users/123", params);
+        router.match_route(req, params);
     }
 }
 BENCHMARK(BM_Router_Parameterized);
 
-static void BM_Router_Wildcard(benchmark::State& state) {
+static void BM_Router_Wildcard(benchmark::State& state)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/static/*path", dummy_handler);
-    for (auto _ : state) {
+    mycppwebfw::http::Request req = {"GET", "/static/css/style.css"};
+    for (auto _ : state)
+    {
         std::unordered_map<std::string, std::string> params;
-        router.match_route("GET", "/static/css/style.css", params);
+        router.match_route(req, params);
     }
 }
 BENCHMARK(BM_Router_Wildcard);
 
-static void BM_OptionalParameterRoute(benchmark::State& state) {
+static void BM_OptionalParameterRoute(benchmark::State& state)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/users/:id?", dummy_handler);
+    mycppwebfw::http::Request req = {"GET", "/users/123"};
     std::unordered_map<std::string, std::string> params;
-    for (auto _ : state) {
-        router.match_route("GET", "/users/123", params);
+    for (auto _ : state)
+    {
+        router.match_route(req, params);
     }
 }
 BENCHMARK(BM_OptionalParameterRoute);
 
-static void BM_DefaultParameterRoute(benchmark::State& state) {
+static void BM_DefaultParameterRoute(benchmark::State& state)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/lang/:locale=en", dummy_handler);
+    mycppwebfw::http::Request req = {"GET", "/lang"};
     std::unordered_map<std::string, std::string> params;
-    for (auto _ : state) {
-        router.match_route("GET", "/lang", params);
+    for (auto _ : state)
+    {
+        router.match_route(req, params);
     }
 }
 BENCHMARK(BM_DefaultParameterRoute);
+
+static void BM_Router_MultiMethod(benchmark::State& state)
+{
+    mycppwebfw::routing::Router router;
+    router.add_route("GET", "/hello", dummy_handler);
+    router.add_route("POST", "/hello", dummy_handler);
+    router.add_route("PUT", "/hello", dummy_handler);
+    router.add_route("DELETE", "/hello", dummy_handler);
+    mycppwebfw::http::Request req = {"DELETE", "/hello"};
+    for (auto _ : state)
+    {
+        std::unordered_map<std::string, std::string> params;
+        router.match_route(req, params);
+    }
+}
+BENCHMARK(BM_Router_MultiMethod);
 
 BENCHMARK_MAIN();

--- a/mycppwebfw/include/mycppwebfw/http/request.h
+++ b/mycppwebfw/include/mycppwebfw/http/request.h
@@ -1,13 +1,23 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "mycppwebfw/http/header.h"
 
-namespace mycppwebfw {
-namespace http {
+namespace mycppwebfw
+{
+namespace http
+{
 
-struct Request {
+class Request
+{
+public:
+    std::string get_method() const;
+    std::string get_path() const;
+    std::string get_header(const std::string& name) const;
+    std::unordered_map<std::string, std::string> get_query_params() const;
+
     std::string method;
     std::string uri;
     int http_version_major;
@@ -16,5 +26,5 @@ struct Request {
     std::string body;
 };
 
-} // namespace http
-} // namespace mycppwebfw
+}  // namespace http
+}  // namespace mycppwebfw

--- a/mycppwebfw/include/mycppwebfw/routing/route_matcher.h
+++ b/mycppwebfw/include/mycppwebfw/routing/route_matcher.h
@@ -2,13 +2,18 @@
 
 #include "mycppwebfw/routing/router.h"
 
-namespace mycppwebfw {
-namespace routing {
+namespace mycppwebfw
+{
+namespace routing
+{
 
-class RouteMatcher {
+class RouteMatcher
+{
 public:
-    static HttpHandler match(const std::shared_ptr<TrieNode>& root, const std::string& path, std::unordered_map<std::string, std::string>& params);
+    static std::shared_ptr<TrieNode>
+    match(const std::shared_ptr<TrieNode>& root, const std::string& path,
+          std::unordered_map<std::string, std::string>& params);
 };
 
-} // namespace routing
-} // namespace mycppwebfw
+}  // namespace routing
+}  // namespace mycppwebfw

--- a/mycppwebfw/include/mycppwebfw/routing/router.h
+++ b/mycppwebfw/include/mycppwebfw/routing/router.h
@@ -1,48 +1,67 @@
 #pragma once
 
-#include <string>
-#include <vector>
-#include <memory>
 #include <functional>
+#include <memory>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "mycppwebfw/http/request.h"
 #include "mycppwebfw/http/response.h"
 
-namespace mycppwebfw {
-namespace routing {
+namespace mycppwebfw
+{
+namespace routing
+{
 
 using HttpHandler = std::function<void(http::Request&, http::Response&)>;
 
-enum class NodeType {
+enum class NodeType
+{
     STATIC,
     PARAMETER,
     WILDCARD
 };
 
-struct TrieNode {
+struct TrieNode
+{
     std::string part;
     NodeType type;
     std::unordered_map<std::string, std::shared_ptr<TrieNode>> children;
     HttpHandler handler = nullptr;
+    std::vector<HttpHandler> middlewares;
     bool is_wildcard = false;
     bool is_optional = false;
     std::string default_value;
 
-    TrieNode(const std::string& part, NodeType type) : part(part), type(type) {}
+    TrieNode(const std::string& part, NodeType type) : part(part), type(type)
+    {
+    }
 };
 
-class Router {
+class Router
+{
 public:
     Router();
     ~Router();
 
-    void add_route(const std::string& method, const std::string& path, HttpHandler handler);
-    HttpHandler match_route(const std::string& method, const std::string& path, std::unordered_map<std::string, std::string>& params);
+    void add_route(const std::string& method, const std::string& path,
+                   HttpHandler handler,
+                   const std::vector<HttpHandler>& middlewares = {});
+    struct MatchResult
+    {
+        HttpHandler handler;
+        std::vector<HttpHandler> middlewares;
+        std::vector<std::string> allowed_methods;
+    };
+
+    MatchResult
+    match_route(http::Request& request,
+                std::unordered_map<std::string, std::string>& params);
 
 private:
     std::unordered_map<std::string, std::shared_ptr<TrieNode>> trees;
 };
 
-} // namespace routing
-} // namespace mycppwebfw
+}  // namespace routing
+}  // namespace mycppwebfw

--- a/mycppwebfw/src/http/request.cpp
+++ b/mycppwebfw/src/http/request.cpp
@@ -1,0 +1,67 @@
+#include "mycppwebfw/http/request.h"
+#include <algorithm>
+
+namespace mycppwebfw
+{
+namespace http
+{
+
+std::string Request::get_method() const
+{
+    return method;
+}
+
+std::string Request::get_path() const
+{
+    size_t pos = uri.find('?');
+    if (pos != std::string::npos)
+    {
+        return uri.substr(0, pos);
+    }
+    return uri;
+}
+
+std::string Request::get_header(const std::string& name) const
+{
+    auto it =
+        std::find_if(headers.begin(), headers.end(),
+                     [&](const Header& header) { return header.name == name; });
+    if (it != headers.end())
+    {
+        return it->value;
+    }
+    return "";
+}
+
+std::unordered_map<std::string, std::string> Request::get_query_params() const
+{
+    std::unordered_map<std::string, std::string> params;
+    size_t pos = uri.find('?');
+    if (pos != std::string::npos)
+    {
+        std::string query_string = uri.substr(pos + 1);
+        std::string key;
+        std::string value;
+        size_t start = 0;
+        for (size_t i = 0; i < query_string.length(); ++i)
+        {
+            if (query_string[i] == '=')
+            {
+                key = query_string.substr(start, i - start);
+                start = i + 1;
+            }
+            else if (query_string[i] == '&')
+            {
+                value = query_string.substr(start, i - start);
+                params[key] = value;
+                start = i + 1;
+            }
+        }
+        value = query_string.substr(start);
+        params[key] = value;
+    }
+    return params;
+}
+
+}  // namespace http
+}  // namespace mycppwebfw

--- a/mycppwebfw/src/routing/route_matcher.cpp
+++ b/mycppwebfw/src/routing/route_matcher.cpp
@@ -1,30 +1,44 @@
 #include "mycppwebfw/routing/route_matcher.h"
 #include <sstream>
 
-namespace mycppwebfw {
-namespace routing {
+namespace mycppwebfw
+{
+namespace routing
+{
 
-HttpHandler RouteMatcher::match(const std::shared_ptr<TrieNode>& root, const std::string& path, std::unordered_map<std::string, std::string>& params) {
+std::shared_ptr<TrieNode>
+RouteMatcher::match(const std::shared_ptr<TrieNode>& root,
+                    const std::string& path,
+                    std::unordered_map<std::string, std::string>& params)
+{
     std::stringstream ss(path);
     std::string segment;
     std::vector<std::string> segments;
-    while (std::getline(ss, segment, '/')) {
-        if (!segment.empty()) {
+    while (std::getline(ss, segment, '/'))
+    {
+        if (!segment.empty())
+        {
             segments.push_back(segment);
         }
     }
 
     std::shared_ptr<TrieNode> current = root;
     size_t segment_index = 0;
-    while (segment_index < segments.size()) {
+    while (segment_index < segments.size())
+    {
         const auto& seg = segments[segment_index];
-        if (current->children.find(seg) != current->children.end()) {
+        if (current->children.find(seg) != current->children.end())
+        {
             current = current->children[seg];
             segment_index++;
-        } else {
+        }
+        else
+        {
             bool found = false;
-            for (auto const& [key, val] : current->children) {
-                if (val->type == NodeType::PARAMETER) {
+            for (auto const& [key, val] : current->children)
+            {
+                if (val->type == NodeType::PARAMETER)
+                {
                     params[val->part] = seg;
                     current = val;
                     found = true;
@@ -32,37 +46,48 @@ HttpHandler RouteMatcher::match(const std::shared_ptr<TrieNode>& root, const std
                     break;
                 }
             }
-            if (found) continue;
+            if (found)
+                continue;
 
-            for (auto const& [key, val] : current->children) {
-                if (val->type == NodeType::WILDCARD) {
+            for (auto const& [key, val] : current->children)
+            {
+                if (val->type == NodeType::WILDCARD)
+                {
                     std::string remaining_path;
-                    for (size_t i = segment_index; i < segments.size(); ++i) {
+                    for (size_t i = segment_index; i < segments.size(); ++i)
+                    {
                         remaining_path += segments[i];
-                        if (i < segments.size() - 1) {
+                        if (i < segments.size() - 1)
+                        {
                             remaining_path += "/";
                         }
                     }
                     params[val->part] = remaining_path;
-                    return val->handler;
+                    return val;
                 }
             }
             return nullptr;
         }
     }
 
-    if (current && current->handler) {
-        return current->handler;
+    if (current && current->handler)
+    {
+        return current;
     }
 
-    if (current) {
-        for (auto const& [key, val] : current->children) {
-            if (val->is_optional) {
-                if (!val->default_value.empty()) {
+    if (current)
+    {
+        for (auto const& [key, val] : current->children)
+        {
+            if (val->is_optional)
+            {
+                if (!val->default_value.empty())
+                {
                     params[val->part] = val->default_value;
                 }
-                if (val->handler) {
-                    return val->handler;
+                if (val->handler)
+                {
+                    return val;
                 }
             }
         }
@@ -71,5 +96,5 @@ HttpHandler RouteMatcher::match(const std::shared_ptr<TrieNode>& root, const std
     return nullptr;
 }
 
-} // namespace routing
-} // namespace mycppwebfw
+}  // namespace routing
+}  // namespace mycppwebfw

--- a/mycppwebfw/src/utils/logger.cpp
+++ b/mycppwebfw/src/utils/logger.cpp
@@ -1,0 +1,27 @@
+#include "utils/logger.h"
+#include <iostream>
+
+namespace mycppwebfw {
+namespace utils {
+
+void Logger::log(LogLevel level, const std::string& message) {
+    std::string level_str;
+    switch (level) {
+        case LogLevel::DEBUG:
+            level_str = "DEBUG";
+            break;
+        case LogLevel::INFO:
+            level_str = "INFO";
+            break;
+        case LogLevel::WARNING:
+            level_str = "WARNING";
+            break;
+        case LogLevel::ERROR:
+            level_str = "ERROR";
+            break;
+    }
+    std::cout << "[" << level_str << "] " << message << std::endl;
+}
+
+} // namespace utils
+} // namespace mycppwebfw

--- a/mycppwebfw/src/utils/logger.h
+++ b/mycppwebfw/src/utils/logger.h
@@ -1,1 +1,25 @@
-// Logger utility
+#pragma once
+
+#include <string>
+
+namespace mycppwebfw
+{
+namespace utils
+{
+
+enum class LogLevel
+{
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR
+};
+
+class Logger
+{
+public:
+    static void log(LogLevel level, const std::string& message);
+};
+
+}  // namespace utils
+}  // namespace mycppwebfw

--- a/mycppwebfw/tests/routing_tests/router_test.cpp
+++ b/mycppwebfw/tests/routing_tests/router_test.cpp
@@ -1,100 +1,128 @@
-#include "gtest/gtest.h"
 #include "mycppwebfw/routing/router.h"
+#include "gtest/gtest.h"
+#include "mycppwebfw/http/request.h"
+#include "mycppwebfw/http/response.h"
 #include "mycppwebfw/routing/parameter_parser.h"
 
-void dummy_handler(mycppwebfw::http::Request&, mycppwebfw::http::Response&) {}
+void dummy_handler(mycppwebfw::http::Request&, mycppwebfw::http::Response&)
+{
+}
 
-TEST(RouterTest, StaticRoute) {
+TEST(RouterTest, StaticRoute)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/hello", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler = router.match_route("GET", "/hello", params);
-    ASSERT_NE(handler, nullptr);
+    mycppwebfw::http::Request req = {"GET", "/hello"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
 }
 
-TEST(RouterTest, ParameterizedRoute) {
+TEST(RouterTest, ParameterizedRoute)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/users/:id", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler = router.match_route("GET", "/users/123", params);
-    ASSERT_NE(handler, nullptr);
+    mycppwebfw::http::Request req = {"GET", "/users/123"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
     ASSERT_EQ(params["id"], "123");
 }
 
-TEST(RouterTest, WildcardRoute) {
+TEST(RouterTest, WildcardRoute)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/static/*path", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler = router.match_route("GET", "/static/css/style.css", params);
-    ASSERT_NE(handler, nullptr);
+    mycppwebfw::http::Request req = {"GET", "/static/css/style.css"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
     ASSERT_EQ(params["path"], "css/style.css");
 }
 
-TEST(RouterTest, RouteNotFound) {
+TEST(RouterTest, RouteNotFound)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/hello", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler = router.match_route("GET", "/world", params);
-    ASSERT_EQ(handler, nullptr);
+    mycppwebfw::http::Request req = {"GET", "/world"};
+    auto result = router.match_route(req, params);
+    ASSERT_EQ(result.handler, nullptr);
 }
 
-TEST(RouterTest, MethodNotFound) {
+TEST(RouterTest, MethodNotFound)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/hello", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler = router.match_route("POST", "/hello", params);
-    ASSERT_EQ(handler, nullptr);
+    mycppwebfw::http::Request req = {"POST", "/hello"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
+    ASSERT_EQ(result.allowed_methods.size(), 1);
+    ASSERT_EQ(result.allowed_methods[0], "GET");
 }
 
-TEST(RouterTest, OverlappingRoutes) {
+TEST(RouterTest, OverlappingRoutes)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/users/new", dummy_handler);
     router.add_route("GET", "/users/:id", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler1 = router.match_route("GET", "/users/new", params);
-    ASSERT_NE(handler1, nullptr);
-    auto handler2 = router.match_route("GET", "/users/123", params);
-    ASSERT_NE(handler2, nullptr);
+    mycppwebfw::http::Request req1 = {"GET", "/users/new"};
+    auto result1 = router.match_route(req1, params);
+    ASSERT_NE(result1.handler, nullptr);
+    mycppwebfw::http::Request req2 = {"GET", "/users/123"};
+    auto result2 = router.match_route(req2, params);
+    ASSERT_NE(result2.handler, nullptr);
     ASSERT_EQ(params["id"], "123");
 }
 
-TEST(RouterTest, OptionalParameter) {
+TEST(RouterTest, OptionalParameter)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/users/:id?", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler1 = router.match_route("GET", "/users/123", params);
-    ASSERT_NE(handler1, nullptr);
+    mycppwebfw::http::Request req1 = {"GET", "/users/123"};
+    auto result1 = router.match_route(req1, params);
+    ASSERT_NE(result1.handler, nullptr);
     ASSERT_EQ(params["id"], "123");
     params.clear();
-    auto handler2 = router.match_route("GET", "/users", params);
-    ASSERT_NE(handler2, nullptr);
+    mycppwebfw::http::Request req2 = {"GET", "/users"};
+    auto result2 = router.match_route(req2, params);
+    ASSERT_NE(result2.handler, nullptr);
     ASSERT_EQ(params.find("id"), params.end());
 }
 
-TEST(RouterTest, DefaultParameter) {
+TEST(RouterTest, DefaultParameter)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/lang/:locale=en", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler1 = router.match_route("GET", "/lang/fr", params);
-    ASSERT_NE(handler1, nullptr);
+    mycppwebfw::http::Request req1 = {"GET", "/lang/fr"};
+    auto result1 = router.match_route(req1, params);
+    ASSERT_NE(result1.handler, nullptr);
     ASSERT_EQ(params["locale"], "fr");
     params.clear();
-    auto handler2 = router.match_route("GET", "/lang", params);
-    ASSERT_NE(handler2, nullptr);
+    mycppwebfw::http::Request req2 = {"GET", "/lang"};
+    auto result2 = router.match_route(req2, params);
+    ASSERT_NE(result2.handler, nullptr);
     ASSERT_EQ(params["locale"], "en");
 }
 
-TEST(RouterTest, WildcardPrecedence) {
+TEST(RouterTest, WildcardPrecedence)
+{
     mycppwebfw::routing::Router router;
     router.add_route("GET", "/user/specific", dummy_handler);
     router.add_route("GET", "/user/*path", dummy_handler);
     std::unordered_map<std::string, std::string> params;
-    auto handler = router.match_route("GET", "/user/specific", params);
-    ASSERT_NE(handler, nullptr);
+    mycppwebfw::http::Request req = {"GET", "/user/specific"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
     ASSERT_EQ(params.size(), 0);
 }
 
-TEST(RouterTest, ParameterTypeConversion) {
+TEST(RouterTest, ParameterTypeConversion)
+{
     std::string id_str = "123";
     int id_int = mycppwebfw::routing::ParameterParser::parse<int>(id_str);
     ASSERT_EQ(id_int, 123);
@@ -104,10 +132,53 @@ TEST(RouterTest, ParameterTypeConversion) {
     ASSERT_FLOAT_EQ(pi_float, 3.14f);
 }
 
-TEST(RouterTest, ParameterValidation) {
+TEST(RouterTest, ParameterValidation)
+{
     std::string valid_email = "test@example.com";
     std::string invalid_email = "not-an-email";
-    std::string email_pattern = R"(^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$)";
-    ASSERT_TRUE(mycppwebfw::routing::ParameterParser::validate(valid_email, email_pattern));
-    ASSERT_FALSE(mycppwebfw::routing::ParameterParser::validate(invalid_email, email_pattern));
+    std::string email_pattern =
+        R"(^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$)";
+    ASSERT_TRUE(mycppwebfw::routing::ParameterParser::validate(valid_email,
+                                                               email_pattern));
+    ASSERT_FALSE(mycppwebfw::routing::ParameterParser::validate(invalid_email,
+                                                                email_pattern));
+}
+
+TEST(RouterTest, MethodOverrideHeader)
+{
+    mycppwebfw::routing::Router router;
+    router.add_route("PUT", "/users/123", dummy_handler);
+    std::unordered_map<std::string, std::string> params;
+    mycppwebfw::http::Request req = {
+        "POST", "/users/123", 1, 1, {{"X-HTTP-Method-Override", "PUT"}}, ""};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
+}
+
+TEST(RouterTest, MethodOverrideQuery)
+{
+    mycppwebfw::routing::Router router;
+    router.add_route("PUT", "/users/123", dummy_handler);
+    std::unordered_map<std::string, std::string> params;
+    mycppwebfw::http::Request req = {"POST", "/users/123?_method=PUT"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
+}
+
+TEST(RouterTest, Middleware)
+{
+    mycppwebfw::routing::Router router;
+    bool middleware_called = false;
+    mycppwebfw::routing::HttpHandler middleware =
+        [&](mycppwebfw::http::Request&, mycppwebfw::http::Response&)
+    { middleware_called = true; };
+    router.add_route("GET", "/hello", dummy_handler, {middleware});
+    std::unordered_map<std::string, std::string> params;
+    mycppwebfw::http::Request req = {"GET", "/hello"};
+    auto result = router.match_route(req, params);
+    ASSERT_NE(result.handler, nullptr);
+    ASSERT_EQ(result.middlewares.size(), 1);
+    mycppwebfw::http::Response res;
+    result.middlewares[0](req, res);
+    ASSERT_TRUE(middleware_called);
 }


### PR DESCRIPTION
This commit introduces HTTP method-specific routing to the framework.

- Adds separate routing trees for each HTTP method (GET, POST, PUT, DELETE, etc.).
- Implements 405 Method Not Allowed responses when a path exists but the method is not supported.
- Adds support for method-specific middleware chains.
- Implements HTTP method override via the `_method` query parameter or the `X-HTTP-Method-Override` header.
- Adds logging for method resolution, 405 generation, and middleware invocation.