### PR TITLE
feat: Implement route priorities and conflict detection

### DIFF
--- a/mycppwebfw/include/mycppwebfw/routing/router.h
+++ b/mycppwebfw/include/mycppwebfw/routing/router.h
@@ -8,6 +8,7 @@
 
 #include "mycppwebfw/http/request.h"
 #include "mycppwebfw/http/response.h"
+#include "mycppwebfw/utils/logger.h"
 
 namespace mycppwebfw
 {
@@ -33,6 +34,7 @@ struct TrieNode
     bool is_wildcard = false;
     bool is_optional = false;
     std::string default_value;
+    int priority = 0;
 
     TrieNode(const std::string& part, NodeType type) : part(part), type(type)
     {
@@ -48,7 +50,7 @@ public:
     void add_route(const std::string& method, const std::string& path,
                    HttpHandler handler,
                    const std::vector<HttpHandler>& middlewares = {},
-                   const std::string& name = "");
+                   const std::string& name = "", int priority = 0);
     void group(const std::string& prefix,
                const std::vector<HttpHandler>& middlewares,
                const std::function<void(RouteGroup&)>& group_routes);
@@ -68,7 +70,7 @@ public:
     void add_route(const std::string& method, const std::string& path,
                    HttpHandler handler,
                    const std::vector<HttpHandler>& middlewares = {},
-                   const std::string& name = "");
+                   const std::string& name = "", int priority = 0);
     void group(const std::string& prefix,
                const std::function<void(RouteGroup&)>& group_routes);
     void group(const std::string& prefix,

--- a/mycppwebfw/src/utils/logger.cpp
+++ b/mycppwebfw/src/utils/logger.cpp
@@ -1,26 +1,55 @@
-#include "utils/logger.h"
+#include "mycppwebfw/utils/logger.h"
 #include <iostream>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
 
 namespace mycppwebfw {
 namespace utils {
 
-void Logger::log(LogLevel level, const std::string& message) {
-    std::string level_str;
+static std::string levelToString(LogLevel level) {
     switch (level) {
         case LogLevel::DEBUG:
-            level_str = "DEBUG";
-            break;
+            return "DEBUG";
         case LogLevel::INFO:
-            level_str = "INFO";
-            break;
+            return "INFO";
         case LogLevel::WARNING:
-            level_str = "WARNING";
-            break;
+            return "WARNING";
         case LogLevel::ERROR:
-            level_str = "ERROR";
-            break;
+            return "ERROR";
     }
-    std::cout << "[" << level_str << "] " << message << std::endl;
+    return "";
+}
+
+void Logger::log(LogLevel level, const std::string& message) {
+    // Get current time
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+
+    // Format timestamp
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S");
+
+    // Output log message
+    std::cout << "[" << ss.str() << "] "
+              << "[" << levelToString(level) << "] "
+              << message << std::endl;
+}
+
+void Logger::log(LogLevel level, const std::string& message, const char* file, int line) {
+    // Get current time
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+
+    // Format timestamp
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&time_t), "%Y-%m-%d %H:%M:%S");
+
+    // Output log message with file and line info
+    std::cout << "[" << ss.str() << "] "
+              << "[" << levelToString(level) << "] "
+              << "[" << file << ":" << line << "] "
+              << message << std::endl;
 }
 
 } // namespace utils

--- a/mycppwebfw/src/utils/logger.h
+++ b/mycppwebfw/src/utils/logger.h
@@ -19,7 +19,15 @@ class Logger
 {
 public:
     static void log(LogLevel level, const std::string& message);
+    static void log(LogLevel level, const std::string& message, const char* file, int line);
 };
+}  // namespace utils
+}  // namespace mycppwebfw
+
+#define LOG_DEBUG(msg) mycppwebfw::utils::Logger::log(mycppwebfw::utils::LogLevel::DEBUG, msg, __FILE__, __LINE__)
+#define LOG_INFO(msg) mycppwebfw::utils::Logger::log(mycppwebfw::utils::LogLevel::INFO, msg, __FILE__, __LINE__)
+#define LOG_WARNING(msg) mycppwebfw::utils::Logger::log(mycppwebfw::utils::LogLevel::WARNING, msg, __FILE__, __LINE__)
+#define LOG_ERROR(msg) mycppwebfw::utils::Logger::log(mycppwebfw::utils::LogLevel::ERROR, msg, __FILE__, __LINE__)
 
 }  // namespace utils
 }  // namespace mycppwebfw


### PR DESCRIPTION
This commit introduces a route priority system to ensure deterministic routing behavior.

Changes:
- Added a `priority` field to the `TrieNode` struct.
- Updated `add_route` to accept a `priority` parameter.
- Implemented conflict detection to log a warning when a route conflicts with an existing one.
- Modified the `RouteMatcher` to select the route with the highest priority.
- Updated the logger to include file and line numbers.
- Added new tests for route precedence, conflict detection, and manual priority overrides.

Known Issues:
- The build is failing due to issues with the logging macros. The `LOG_*` macros are not being found in `router.cpp` and other files, even though the `logger.h` file is included. I have tried various include orders and locations, but the issue persists. I suspect there might be a problem with the CMake configuration or the way the headers are being included.