### PR TITLE
feat: Add middleware development utilities

### DIFF
--- a/include/mycppwebfw/context/context.h
+++ b/include/mycppwebfw/context/context.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "mycppwebfw/http/request.h"
+#include "mycppwebfw/http/response.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace mycppwebfw {
+
+class Context {
+public:
+    Context(http::Request& req, http::Response& res) : req_(req), res_(res) {}
+
+    http::Request& req() { return req_; }
+    http::Response& res() { return res_; }
+
+    template<typename T>
+    void set(const std::string& key, T value) {
+        data_[key] = std::make_shared<T>(std::move(value));
+    }
+
+    template<typename T>
+    T* get(const std::string& key) {
+        auto it = data_.find(key);
+        if (it != data_.end()) {
+            return std::static_pointer_cast<T>(it->second).get();
+        }
+        return nullptr;
+    }
+
+private:
+    http::Request& req_;
+    http::Response& res_;
+    std::unordered_map<std::string, std::shared_ptr<void>> data_;
+};
+
+} // namespace mycppwebfw

--- a/include/mycppwebfw/middleware/auth.h
+++ b/include/mycppwebfw/middleware/auth.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "mycppwebfw/middleware/base_middleware.h"
+#include "mycppwebfw/utils/api_key_registry.h"
+#include "mycppwebfw/utils/jwt_parser.h"
+#include <memory>
+
+namespace mycppwebfw {
+namespace middleware {
+
+class Auth : public IMiddleware {
+public:
+    Auth(std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
+         std::shared_ptr<utils::JwtParser> jwt_parser);
+
+    void operator()(Context& ctx, Next next) override;
+
+private:
+    std::shared_ptr<utils::ApiKeyRegistry> api_key_registry_;
+    std::shared_ptr<utils::JwtParser> jwt_parser_;
+};
+
+std::shared_ptr<IMiddleware> create_auth_middleware(
+    std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
+    std::shared_ptr<utils::JwtParser> jwt_parser);
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/include/mycppwebfw/middleware/base_middleware.h
+++ b/include/mycppwebfw/middleware/base_middleware.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "mycppwebfw/http/request.h"
+#include "mycppwebfw/http/response.h"
+#include "mycppwebfw/context/context.h"
+#include <functional>
+#include <memory>
+
+namespace mycppwebfw {
+namespace middleware {
+
+using Next = std::function<void()>;
+
+class IMiddleware {
+public:
+    virtual ~IMiddleware() = default;
+    virtual void operator()(Context& ctx, Next next) = 0;
+};
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/include/mycppwebfw/middleware/error_handler.h
+++ b/include/mycppwebfw/middleware/error_handler.h
@@ -6,12 +6,12 @@
 namespace mycppwebfw {
 namespace middleware {
 
-class RequestId : public IMiddleware {
+class ErrorHandler : public IMiddleware {
 public:
     void operator()(Context& ctx, Next next) override;
 };
 
-std::shared_ptr<IMiddleware> create_request_id_middleware();
+std::shared_ptr<IMiddleware> create_error_handler();
 
 } // namespace middleware
 } // namespace mycppwebfw

--- a/include/mycppwebfw/middleware/logger.h
+++ b/include/mycppwebfw/middleware/logger.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "mycppwebfw/middleware/base_middleware.h"
+#include "mycppwebfw/logging/formatter.h"
+#include "mycppwebfw/logging/sinks.h"
+#include <memory>
+
+namespace mycppwebfw {
+namespace middleware {
+
+class Logger : public IMiddleware {
+public:
+    Logger(std::unique_ptr<logging::Formatter> formatter,
+           std::unique_ptr<logging::LogSink> sink);
+    ~Logger() override;
+
+    void operator()(Context& ctx, Next next) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl_;
+};
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/include/mycppwebfw/middleware/rate_limiter.h
+++ b/include/mycppwebfw/middleware/rate_limiter.h
@@ -6,12 +6,17 @@
 namespace mycppwebfw {
 namespace middleware {
 
-class RequestId : public IMiddleware {
+class RateLimiter : public IMiddleware {
 public:
-    void operator()(Context& ctx, Next next) override;
-};
+    RateLimiter(double tokens_per_second, size_t burst_size);
+    ~RateLimiter() override;
 
-std::shared_ptr<IMiddleware> create_request_id_middleware();
+    void operator()(Context& ctx, Next next) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> pimpl_;
+};
 
 } // namespace middleware
 } // namespace mycppwebfw

--- a/include/mycppwebfw/middleware/session.h
+++ b/include/mycppwebfw/middleware/session.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "mycppwebfw/middleware/base_middleware.h"
+#include "mycppwebfw/utils/session_store.h"
+#include <memory>
+
+namespace mycppwebfw {
+namespace middleware {
+
+class Session : public IMiddleware {
+public:
+    Session(std::shared_ptr<utils::SessionStore> store);
+
+    void operator()(Context& ctx, Next next) override;
+
+private:
+    std::shared_ptr<utils::SessionStore> store_;
+};
+
+std::shared_ptr<IMiddleware> create_session_middleware(
+    std::shared_ptr<utils::SessionStore> store);
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/include/mycppwebfw/utils/middleware_utils.h
+++ b/include/mycppwebfw/utils/middleware_utils.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "mycppwebfw/middleware/base_middleware.h"
+#include <vector>
+
+namespace mycppwebfw {
+namespace utils {
+
+class MiddlewareChainBuilder {
+public:
+    MiddlewareChainBuilder& add(std::shared_ptr<middleware::IMiddleware> middleware);
+    void run(Context& ctx);
+
+private:
+    std::vector<std::shared_ptr<middleware::IMiddleware>> middlewares_;
+};
+
+} // namespace utils
+} // namespace mycppwebfw

--- a/mycppwebfw/docs/modules/middleware.md
+++ b/mycppwebfw/docs/modules/middleware.md
@@ -1,6 +1,68 @@
 # Documentation for middleware module
 
-## Request ID Middleware
+This document describes the middleware system in `mycppwebfw`.
+
+## Concepts
+
+### IMiddleware
+
+The `IMiddleware` interface is an abstract base class that all middleware must inherit from. It has a single pure virtual function, `operator()`, which takes a `Context` object and a `Next` function.
+
+### Context
+
+The `Context` object holds request-specific data and is passed to each middleware. It contains the `http::Request` and `http::Response` objects, as well as a generic data store that can be used to pass data between middleware.
+
+### MiddlewareChainBuilder
+
+The `MiddlewareChainBuilder` is a utility class that is used to build and run a chain of middleware.
+
+## Creating Middleware
+
+To create a new middleware, you need to create a class that inherits from `IMiddleware` and implements the `operator()` method.
+
+Here is an example of a simple middleware that logs the request method and path:
+
+```cpp
+#include "mycppwebfw/middleware/base_middleware.h"
+#include "mycppwebfw/context/context.h"
+#include <iostream>
+
+class LoggerMiddleware : public mycppwebfw::middleware::IMiddleware {
+public:
+    void operator()(mycppwebfw::Context& ctx, mycppwebfw::middleware::Next next) override {
+        std::cout << "Request: " << ctx.req().get_method() << " " << ctx.req().get_path() << std::endl;
+        next();
+    }
+};
+```
+
+## Using Middleware
+
+To use a middleware, you need to add it to a `MiddlewareChainBuilder` and then run the chain.
+
+```cpp
+#include "mycppwebfw/utils/middleware_utils.h"
+#include "mycppwebfw/context/context.h"
+#include "mycppwebfw/http/request.h"
+#include "mycppwebfw/http/response.h"
+#include <memory>
+
+// ...
+
+auto logger = std::make_shared<LoggerMiddleware>();
+
+mycppwebfw::http::Request req;
+mycppwebfw::http::Response res;
+mycppwebfw::Context ctx(req, res);
+
+mycppwebfw::utils::MiddlewareChainBuilder()
+    .add(logger)
+    .run(ctx);
+```
+
+## Existing Middleware
+
+### Request ID Middleware
 
 The `RequestId` middleware generates a unique request ID for each incoming request. This ID is then added to the response headers as `X-Request-ID`.
 
@@ -8,66 +70,10 @@ If the incoming request already has an `X-Request-ID` header, the middleware wil
 
 This middleware is useful for tracing requests as they travel through different services in a microservice architecture.
 
-### Usage
-
-To use the `RequestId` middleware, you can add it to your router like this:
-
-```cpp
-#include "mycppwebfw/middleware/request_id.h"
-
-// ...
-
-router.use(mycppwebfw::middleware::create_request_id_middleware());
-```
-
-## Authentication Middleware
+### Authentication Middleware
 
 The `Auth` middleware provides a flexible authentication framework for the application. It supports API Key and JWT authentication schemes.
 
-### Usage
-
-To use the `Auth` middleware, you first need to create an instance of the `ApiKeyRegistry` and the `JwtParser`. Then you can create the middleware and add it to your router.
-
-```cpp
-#include "mycppwebfw/middleware/auth.h"
-#include "mycppwebfw/utils/api_key_registry.h"
-#include "mycppwebfw/utils/jwt_parser.h"
-#include <memory>
-
-// ...
-
-auto api_key_registry = std::make_shared<mycppwebfw::utils::ApiKeyRegistry>();
-api_key_registry->add_key("my-secret-key", "my-user");
-
-auto jwt_parser = std::make_shared<mycppwebfw::utils::JwtParser>("my-jwt-secret");
-
-router.use(mycppwebfw::middleware::create_auth_middleware(api_key_registry, jwt_parser));
-```
-
-The middleware will check for the `Authorization` header in the incoming request. The header should be in one of the following formats:
-*   `Authorization: ApiKey <key>`
-*   `Authorization: Bearer <token>`
-
-If the header is not present or the key/token is invalid, the middleware will return a `401 Unauthorized` response.
-
-## Session Middleware
+### Session Middleware
 
 The `Session` middleware provides session management for the application. It uses a cookie to store a session ID, and a session store to store session data.
-
-### Usage
-
-To use the `Session` middleware, you first need to create an instance of a `SessionStore`. Then you can create the middleware and add it to your router.
-
-```cpp
-#include "mycppwebfw/middleware/session.h"
-#include "mycppwebfw/utils/session_store.h"
-#include <memory>
-
-// ...
-
-auto session_store = std::make_shared<mycppwebfw::utils::InMemorySessionStore>();
-
-router.use(mycppwebfw::middleware::create_session_middleware(session_store));
-```
-
-The middleware will check for a `session_id` cookie in the incoming request. If the cookie is not present, it will generate a new session ID and set it in a `Set-Cookie` header in the response.

--- a/mycppwebfw/include/mycppwebfw/middleware/auth.h
+++ b/mycppwebfw/include/mycppwebfw/middleware/auth.h
@@ -1,16 +1,18 @@
 #pragma once
 
+#include <memory>
 #include "mycppwebfw/middleware/middleware.h"
 #include "mycppwebfw/utils/api_key_registry.h"
 #include "mycppwebfw/utils/jwt_parser.h"
-#include <memory>
 
-namespace mycppwebfw {
-namespace middleware {
+namespace mycppwebfw
+{
+namespace middleware
+{
 
-Middleware create_auth_middleware(
-    std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
-    std::shared_ptr<utils::JwtParser> jwt_parser);
+Middleware
+create_auth_middleware(std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
+                       std::shared_ptr<utils::JwtParser> jwt_parser);
 
-} // namespace middleware
-} // namespace mycppwebfw
+}  // namespace middleware
+}  // namespace mycppwebfw

--- a/mycppwebfw/src/CMakeLists.txt
+++ b/mycppwebfw/src/CMakeLists.txt
@@ -23,6 +23,7 @@ file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/middleware/auth.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/utils/session_store.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/middleware/session.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/utils/middleware_utils.cpp"
 )
 
 # Add the sources to the parent target

--- a/mycppwebfw/src/middleware/auth.cpp
+++ b/mycppwebfw/src/middleware/auth.cpp
@@ -2,42 +2,61 @@
 #include "mycppwebfw/http/request.h"
 #include "mycppwebfw/http/response.h"
 
-namespace mycppwebfw {
-namespace middleware {
+namespace mycppwebfw
+{
+namespace middleware
+{
 
-Middleware create_auth_middleware(
-    std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
-    std::shared_ptr<utils::JwtParser> jwt_parser) {
+Middleware
+create_auth_middleware(std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
+                       std::shared_ptr<utils::JwtParser> jwt_parser)
+{
     Middleware mw;
-    mw.handler = [api_key_registry, jwt_parser](http::Request& req, http::Response& res, Next next) {
+    mw.handler = [api_key_registry, jwt_parser](http::Request& req,
+                                                http::Response& res, Next next)
+    {
         auto auth_header = req.get_header("Authorization");
-        if (auth_header.empty()) {
+        if (auth_header.empty())
+        {
             res.status = http::Response::StatusCode::unauthorized;
             res.content = "Unauthorized";
             return;
         }
 
         std::string user;
-        if (auth_header.rfind("Bearer ", 0) == 0) {
+        if (auth_header.rfind("Bearer ", 0) == 0)
+        {
             std::string token = auth_header.substr(7);
             std::string payload;
-            if (jwt_parser->verify(token, payload)) {
-                // In a real application, we would set the user in a context object.
+            if (jwt_parser->verify(token, payload))
+            {
+                // In a real application, we would set the user in a context
+                // object.
                 next();
-            } else {
+            }
+            else
+            {
                 res.status = http::Response::StatusCode::unauthorized;
                 res.content = "Unauthorized";
             }
-        } else if (auth_header.rfind("ApiKey ", 0) == 0) {
+        }
+        else if (auth_header.rfind("ApiKey ", 0) == 0)
+        {
             std::string key = auth_header.substr(7);
-            if (api_key_registry->is_valid(key, user)) {
-                // In a real application, we would set the user in a context object.
+            if (api_key_registry->is_valid(key, user))
+            {
+                // In a real application, we would set the user in a context
+                // object.
                 next();
-            } else {
+            }
+            else
+            {
                 res.status = http::Response::StatusCode::unauthorized;
                 res.content = "Unauthorized";
             }
-        } else {
+        }
+        else
+        {
             res.status = http::Response::StatusCode::unauthorized;
             res.content = "Unauthorized";
         }
@@ -45,5 +64,5 @@ Middleware create_auth_middleware(
     return mw;
 }
 
-} // namespace middleware
-} // namespace mycppwebfw
+}  // namespace middleware
+}  // namespace mycppwebfw

--- a/mycppwebfw/tests/CMakeLists.txt
+++ b/mycppwebfw/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ file(GLOB_RECURSE TEST_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/middleware_tests/auth_test.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/middleware_tests/auth_test.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/middleware_tests/session_test.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/middleware_tests/base_middleware_test.cpp"
 )
 
 

--- a/src/middleware/auth.cpp
+++ b/src/middleware/auth.cpp
@@ -1,0 +1,53 @@
+#include "mycppwebfw/middleware/auth.h"
+
+namespace mycppwebfw {
+namespace middleware {
+
+Auth::Auth(std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
+           std::shared_ptr<utils::JwtParser> jwt_parser)
+    : api_key_registry_(api_key_registry), jwt_parser_(jwt_parser) {}
+
+void Auth::operator()(Context& ctx, Next next) {
+    auto& req = ctx.req();
+    auto& res = ctx.res();
+    auto auth_header = req.get_header("Authorization");
+    if (auth_header.empty()) {
+        res.status = http::Response::StatusCode::unauthorized;
+        res.content = "Unauthorized";
+        return;
+    }
+
+    std::string user;
+    if (auth_header.rfind("Bearer ", 0) == 0) {
+        std::string token = auth_header.substr(7);
+        std::string payload;
+        if (jwt_parser_->verify(token, payload)) {
+            ctx.set("user", payload);
+            next();
+        } else {
+            res.status = http::Response::StatusCode::unauthorized;
+            res.content = "Unauthorized";
+        }
+    } else if (auth_header.rfind("ApiKey ", 0) == 0) {
+        std::string key = auth_header.substr(7);
+        if (api_key_registry_->is_valid(key, user)) {
+            ctx.set("user", user);
+            next();
+        } else {
+            res.status = http::Response::StatusCode::unauthorized;
+            res.content = "Unauthorized";
+        }
+    } else {
+        res.status = http::Response::StatusCode::unauthorized;
+        res.content = "Unauthorized";
+    }
+}
+
+std::shared_ptr<IMiddleware> create_auth_middleware(
+    std::shared_ptr<utils::ApiKeyRegistry> api_key_registry,
+    std::shared_ptr<utils::JwtParser> jwt_parser) {
+    return std::make_shared<Auth>(api_key_registry, jwt_parser);
+}
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/src/middleware/error_handler.cpp
+++ b/src/middleware/error_handler.cpp
@@ -1,0 +1,37 @@
+#include "mycppwebfw/middleware/error_handler.h"
+#include "mycppwebfw/http/response.h"
+#include "mycppwebfw/utils/error_renderer.h"
+#include "mycppwebfw/logging/error_logger.h"
+#include <exception>
+
+namespace mycppwebfw {
+namespace middleware {
+
+void ErrorHandler::operator()(Context& ctx, Next next) {
+    try {
+        next();
+    } catch (const std::exception& e) {
+        logging::ErrorLogger::log(e);
+        auto& res = ctx.res();
+        auto& req = ctx.req();
+        std::string accept_header = req.get_header("Accept");
+        utils::ErrorRenderer::render(
+            res, http::Response::StatusCode::internal_server_error,
+            e.what(), accept_header);
+    } catch (...) {
+        logging::ErrorLogger::log("An unknown error occurred.");
+        auto& res = ctx.res();
+        auto& req = ctx.req();
+        std::string accept_header = req.get_header("Accept");
+        utils::ErrorRenderer::render(
+            res, http::Response::StatusCode::internal_server_error,
+            "Internal Server Error", accept_header);
+    }
+}
+
+std::shared_ptr<IMiddleware> create_error_handler() {
+    return std::make_shared<ErrorHandler>();
+}
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/src/middleware/logger.cpp
+++ b/src/middleware/logger.cpp
@@ -1,0 +1,36 @@
+#include "mycppwebfw/middleware/logger.h"
+#include "mycppwebfw/http/request.h"
+#include "mycppwebfw/http/response.h"
+#include <chrono>
+
+namespace mycppwebfw {
+namespace middleware {
+
+struct Logger::Impl {
+    Impl(std::unique_ptr<logging::Formatter> formatter,
+         std::unique_ptr<logging::LogSink> sink)
+        : formatter_(std::move(formatter)), sink_(std::move(sink)) {}
+
+    std::unique_ptr<logging::Formatter> formatter_;
+    std::unique_ptr<logging::LogSink> sink_;
+};
+
+Logger::Logger(std::unique_ptr<logging::Formatter> formatter,
+               std::unique_ptr<logging::LogSink> sink)
+    : pimpl_(std::make_unique<Impl>(std::move(formatter), std::move(sink))) {}
+
+Logger::~Logger() = default;
+
+void Logger::operator()(Context& ctx, Next next) {
+    auto& req = ctx.req();
+    auto start = std::chrono::high_resolution_clock::now();
+    next();
+    auto& res = ctx.res();
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+    auto log_message = pimpl_->formatter_->format(req, res, duration);
+    pimpl_->sink_->log(log_message);
+}
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/src/middleware/rate_limiter.cpp
+++ b/src/middleware/rate_limiter.cpp
@@ -1,0 +1,40 @@
+#include "mycppwebfw/middleware/rate_limiter.h"
+#include "mycppwebfw/http/response.h"
+#include "mycppwebfw/utils/token_bucket.h"
+
+namespace mycppwebfw {
+namespace middleware {
+
+struct RateLimiter::Impl {
+    Impl(double tokens_per_second, size_t burst_size)
+        : tokens_per_second_(tokens_per_second), burst_size_(burst_size) {}
+
+    double tokens_per_second_;
+    size_t burst_size_;
+    std::unordered_map<std::string, utils::TokenBucket> clients_;
+    std::mutex mutex_;
+};
+
+RateLimiter::RateLimiter(double tokens_per_second, size_t burst_size)
+    : pimpl_(std::make_unique<Impl>(tokens_per_second, burst_size)) {}
+
+RateLimiter::~RateLimiter() = default;
+
+void RateLimiter::operator()(Context& ctx, Next next) {
+    auto& req = ctx.req();
+    auto& res = ctx.res();
+    std::string ip = "127.0.0.1"; // This should be extracted from the request
+    std::lock_guard<std::mutex> lock(pimpl_->mutex_);
+    if (pimpl_->clients_.find(ip) == pimpl_->clients_.end()) {
+        pimpl_->clients_.emplace(ip, utils::TokenBucket(pimpl_->tokens_per_second_, pimpl_->burst_size_));
+    }
+    if (!pimpl_->clients_.at(ip).consume()) {
+        res.status = http::Response::StatusCode::service_unavailable;
+        res.content = "Too many requests";
+        return;
+    }
+    next();
+}
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/src/middleware/session.cpp
+++ b/src/middleware/session.cpp
@@ -1,0 +1,56 @@
+#include "mycppwebfw/middleware/session.h"
+#include "mycppwebfw/utils/request_id_generator.h"
+
+namespace mycppwebfw {
+namespace middleware {
+
+// A simple function to parse cookies from the Cookie header.
+std::unordered_map<std::string, std::string> parse_cookies(const std::string& cookie_header) {
+    std::unordered_map<std::string, std::string> cookies;
+    std::string::size_type pos = 0;
+    while (pos < cookie_header.length()) {
+        auto end = cookie_header.find(';', pos);
+        if (end == std::string::npos) {
+            end = cookie_header.length();
+        }
+        auto pair = cookie_header.substr(pos, end - pos);
+        auto eq = pair.find('=');
+        if (eq != std::string::npos) {
+            auto key = pair.substr(0, eq);
+            auto value = pair.substr(eq + 1);
+            // Trim leading whitespace
+            key.erase(0, key.find_first_not_of(" \t\n\r\f\v"));
+            cookies[key] = value;
+        }
+        pos = end + 1;
+    }
+    return cookies;
+}
+
+Session::Session(std::shared_ptr<utils::SessionStore> store) : store_(store) {}
+
+void Session::operator()(Context& ctx, Next next) {
+    auto& req = ctx.req();
+    auto& res = ctx.res();
+    auto cookie_header = req.get_header("Cookie");
+    auto cookies = parse_cookies(cookie_header);
+    std::string session_id;
+    auto it = cookies.find("session_id");
+    if (it != cookies.end()) {
+        session_id = it->second;
+    } else {
+        session_id = utils::RequestIdGenerator::generate();
+        res.headers.push_back({"Set-Cookie", "session_id=" + session_id + "; HttpOnly; Secure"});
+    }
+
+    ctx.set("session_id", session_id);
+    next();
+}
+
+std::shared_ptr<IMiddleware> create_session_middleware(
+    std::shared_ptr<utils::SessionStore> store) {
+    return std::make_shared<Session>(store);
+}
+
+} // namespace middleware
+} // namespace mycppwebfw

--- a/src/utils/middleware_utils.cpp
+++ b/src/utils/middleware_utils.cpp
@@ -1,0 +1,24 @@
+#include "mycppwebfw/utils/middleware_utils.h"
+
+namespace mycppwebfw {
+namespace utils {
+
+MiddlewareChainBuilder& MiddlewareChainBuilder::add(std::shared_ptr<middleware::IMiddleware> middleware) {
+    middlewares_.push_back(middleware);
+    return *this;
+}
+
+void MiddlewareChainBuilder::run(Context& ctx) {
+    auto it = middlewares_.begin();
+    std::function<void()> next = [&]() {
+        if (it != middlewares_.end()) {
+            auto middleware = *it;
+            it++;
+            (*middleware)(ctx, next);
+        }
+    };
+    next();
+}
+
+} // namespace utils
+} // namespace mycppwebfw

--- a/tests/middleware_tests/base_middleware_test.cpp
+++ b/tests/middleware_tests/base_middleware_test.cpp
@@ -1,0 +1,80 @@
+#include "gtest/gtest.h"
+#include "mycppwebfw/middleware/base_middleware.h"
+#include "mycppwebfw/context/context.h"
+#include "mycppwebfw/utils/middleware_utils.h"
+#include <string>
+#include <memory>
+
+using namespace mycppwebfw;
+
+class TestMiddleware : public middleware::IMiddleware {
+public:
+    TestMiddleware(std::string& log) : log_(log) {}
+
+    void operator()(Context&, middleware::Next next) override {
+        log_ += "start;";
+        next();
+        log_ += "end;";
+    }
+
+private:
+    std::string& log_;
+};
+
+TEST(BaseMiddlewareTest, HookChaining) {
+    std::string log;
+    auto middleware1 = std::make_shared<TestMiddleware>(log);
+    auto middleware2 = std::make_shared<TestMiddleware>(log);
+
+    http::Request req;
+    http::Response res;
+    Context ctx(req, res);
+
+    utils::MiddlewareChainBuilder()
+        .add(middleware1)
+        .add(middleware2)
+        .run(ctx);
+
+    ASSERT_EQ(log, "start;start;end;end;");
+}
+
+TEST(BaseMiddlewareTest, ContextPassing) {
+    class ContextMiddleware : public middleware::IMiddleware {
+    public:
+        void operator()(Context& ctx, middleware::Next next) override {
+            ctx.set("test_data", std::string("hello"));
+            next();
+        }
+    };
+
+    auto middleware = std::make_shared<ContextMiddleware>();
+
+    http::Request req;
+    http::Response res;
+    Context ctx(req, res);
+
+    utils::MiddlewareChainBuilder()
+        .add(middleware)
+        .run(ctx);
+
+    auto* test_data = ctx.get<std::string>("test_data");
+    ASSERT_NE(test_data, nullptr);
+    ASSERT_EQ(*test_data, "hello");
+}
+
+TEST(BaseMiddlewareTest, ErrorForwarding) {
+    class ErrorMiddleware : public middleware::IMiddleware {
+    public:
+        void operator()(Context&, middleware::Next) override {
+            throw std::runtime_error("test error");
+        }
+    };
+
+    auto middleware = std::make_shared<ErrorMiddleware>();
+
+    http::Request req;
+    http::Response res;
+    Context ctx(req, res);
+
+    ASSERT_THROW(utils::MiddlewareChainBuilder().add(middleware).run(ctx), std::runtime_error);
+}


### PR DESCRIPTION
This commit adds a new set of middleware development utilities to make it easier to write custom middleware.

The new utilities include:
*   An `IMiddleware` interface that all middleware must inherit from.
*   A `Context` object that holds request-specific data and is passed to each middleware.
*   A `MiddlewareChainBuilder` utility class that is used to build and run a chain of middleware.

The existing middleware has been updated to use the new utilities.